### PR TITLE
Extract email data

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ When creating your SymfonyConnect authorization URL, you can specify the state a
 ```php
 $options = [
     'state' => 'OPTIONAL_CUSTOM_CONFIGURED_STATE',
-    'scope' => ['SCOPE_PUBLIC SCOPE_EMAIL'] // string
+    'scope' => ['SCOPE_PUBLIC', 'SCOPE_EMAIL'] // array or string ['SCOPE_PUBLIC SCOPE_EMAIL']
 ];
 
 $authorizationUrl = $provider->getAuthorizationUrl($options);

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,28 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="vendor/autoload.php"
-         backupGlobals="false"
-         backupStaticAttributes="false"
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
          colors="true"
-         verbose="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         processIsolation="false"
-         stopOnFailure="false">
-    <testsuites>
-        <testsuite name="SymfonyConnect OAuth2 Test Suite">
-            <directory>tests</directory>
-        </testsuite>
-    </testsuites>
-    <filter>
-        <whitelist>
-            <directory suffix=".php">src/</directory>
-        </whitelist>
-    </filter>
-    <logging>
-        <log type="junit" target="build/report.junit.xml"/>
-        <log type="coverage-html" target="build/coverage"/>
-        <log type="coverage-text" target="build/coverage.txt"/>
-        <log type="coverage-clover" target="build/logs/clover.xml"/>
-    </logging>
+         verbose="true">
+  <coverage>
+    <include>
+      <directory suffix=".php">src/</directory>
+    </include>
+    <report>
+      <clover outputFile="build/logs/clover.xml"/>
+      <html outputDirectory="build/coverage"/>
+      <text outputFile="build/coverage.txt"/>
+    </report>
+  </coverage>
+  <testsuites>
+    <testsuite name="SymfonyConnect OAuth2 Test Suite">
+      <directory>tests</directory>
+    </testsuite>
+  </testsuites>
+  <logging>
+    <junit outputFile="build/report.junit.xml"/>
+  </logging>
 </phpunit>

--- a/src/Provider/SymfonyConnect.php
+++ b/src/Provider/SymfonyConnect.php
@@ -39,14 +39,13 @@ class SymfonyConnect extends AbstractProvider
 
     protected function parseResponse(ResponseInterface $response)
     {
-        $content = (string)$response->getBody();
         $type = $this->getContentType($response);
 
         if ($type !== 'application/vnd.com.symfony.connect+xml') {
             return parent::parseResponse($response);
         }
 
-        return ['xml' => $content];
+        return ['xml' => (string)$response->getBody()];
     }
 
     protected function checkResponse(ResponseInterface $response, $data)

--- a/tests/current_user_response.xml
+++ b/tests/current_user_response.xml
@@ -10,19 +10,17 @@
         xmlns:doap="http://usefulinc.com/ns/doap#"
         xmlns:cv="http://kaste.lv/~captsolo/semweb/resume/cv.rdfs">
     <root>
-        <atom:link rel="https://rels.connect.symfony.com/users" href="https://connect.symfony.com/api/users" type="application/vnd.com.symfony.connect+xml"/>
-        <atom:link rel="https://rels.connect.symfony.com/badges" href="https://connect.symfony.com/api/badges" type="application/vnd.com.symfony.connect+xml" />
         <foaf:Person id="39c049bb-9261-4d85-922c-15730d6fa8b1">
             <foaf:name><![CDATA[John Doe]]></foaf:name>
-            <atom:link rel="https://rels.connect.symfony.com/image" href="https://connect.symfony.com/api/images/xxx.png" type="image/png" />
-            <atom:link rel="self" href="https://connect.symfony.com/api/users/xxx" type="application/vnd.com.symfony.connect+xml"/>
+
+            <atom:link rel="https://rels.connect.symfony.com/image" href="https://connect.symfony.com/api/images/39c049bb-9261-4d85-922c-15730d6fa8b1.png" type="image/png" />
+            <atom:link rel="self" href="https://connect.symfony.com/api/users/39c049bb-9261-4d85-922c-15730d6fa8b1" type="application/vnd.com.symfony.connect+xml"/>
+            <atom:link rel="self" href="https://connect.symfony.com/api/alternates/39c049bb-9261-4d85-922c-15730d6fa8b1" type="text/html" />
+
             <bio:olb><![CDATA[My bio]]></bio:olb>
             <foaf:weblog>https://example.com</foaf:weblog>
-            <foaf:homepage>https://example.co</foaf:homepage>
+            <foaf:homepage>https://example.com</foaf:homepage>
             <foaf:mbox>john@example.com</foaf:mbox>
         </foaf:Person>
-        <xhtml:form id="search_users" method="GET" action="https://connect.symfony.com/api/users" enctype="application/x-www-form-urlencoded">
-            <xhtml:input type="text" name="q" required="required" />
-        </xhtml:form>
     </root>
 </api>

--- a/tests/src/Provider/SymfonyConnectTest.php
+++ b/tests/src/Provider/SymfonyConnectTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Qdequippe\OAuth2\Client\tests\src\Provider;
+namespace Qdequippe\OAuth2\Client\Test\Provider;
 
 use League\OAuth2\Client\Provider\Exception\IdentityProviderException;
 use League\OAuth2\Client\Tool\QueryBuilderTrait;

--- a/tests/src/Provider/SymfonyConnectTest.php
+++ b/tests/src/Provider/SymfonyConnectTest.php
@@ -75,7 +75,7 @@ class SymfonyConnectTest extends TestCase
 
         $postResponse = m::mock('Psr\Http\Message\ResponseInterface');
         $postResponse->shouldReceive('getBody')->andReturn('{"access_token":"mock_access_token"}');
-        $postResponse->shouldReceive('getHeader')->andReturn(['content-type' => 'application/vnd.com.symfony.connect+xml']);
+        $postResponse->shouldReceive('getHeader')->andReturn(['content-type' => 'json']);
         $postResponse->shouldReceive('getStatusCode')->andReturn(200);
         $userResponse = m::mock('Psr\Http\Message\ResponseInterface');
         $userResponse->shouldReceive('getBody')->andReturn($xml);
@@ -91,7 +91,17 @@ class SymfonyConnectTest extends TestCase
         $user = $this->provider->getResourceOwner($token);
 
         $this->assertEquals('39c049bb-9261-4d85-922c-15730d6fa8b1', $user->getId());
-        $this->assertEquals('39c049bb-9261-4d85-922c-15730d6fa8b1', $user->toArray()['id']);
+        $this->assertEquals('john@example.com', $user->getEmail());
+
+        $this->assertEquals(
+            [
+                'id' => '39c049bb-9261-4d85-922c-15730d6fa8b1',
+                'name' => 'John Doe',
+                'email' => 'john@example.com',
+                'profilePicture' => null
+            ],
+            $user->toArray()
+        );
     }
 
     public function testExceptionThrownWhenErrorObjectReceived()


### PR DESCRIPTION
### Main changes

- Added email extraction from SymfonyConnect xml response

### Side changes

- Fixed PHPUnit config as PHPUnit suggested
- Small `SymfonyConnect` provider refactoring
- Improved scope definition, both `string` and `array` definition is possible

closes #1 