### PR TITLE
Give access to response Person data

### DIFF
--- a/src/Provider/SymfonyConnectResourceOwner.php
+++ b/src/Provider/SymfonyConnectResourceOwner.php
@@ -66,6 +66,11 @@ class SymfonyConnectResourceOwner implements ResourceOwnerInterface
         return $this->getLinkNodeHref('./atom:link[@rel="foaf:depiction"]', $this->data);
     }
 
+    public function getData()
+    {
+        return $this->data;
+    }
+
     public function toArray(): array
     {
         return [
@@ -76,7 +81,7 @@ class SymfonyConnectResourceOwner implements ResourceOwnerInterface
         ];
     }
 
-    protected function getNodeValue($query, \DOMElement $element = null, $index = 0)
+    protected function getNodeValue($query, \DOMNode $element = null, $index = 0)
     {
         $nodeList = $this->xpath->query($query, $element);
         if ($nodeList->length > 0 && $index <= $nodeList->length) {
@@ -84,7 +89,7 @@ class SymfonyConnectResourceOwner implements ResourceOwnerInterface
         }
     }
 
-    protected function getLinkNodeHref($query, \DOMElement $element = null, $position = 0)
+    protected function getLinkNodeHref($query, \DOMNode $element = null, $position = 0)
     {
         $nodeList = $this->xpath->query($query, $element);
         if ($nodeList && $nodeList->length > 0 && $nodeList->item($position)) {

--- a/tests/src/Provider/SymfonyConnectTest.php
+++ b/tests/src/Provider/SymfonyConnectTest.php
@@ -7,6 +7,7 @@ use League\OAuth2\Client\Tool\QueryBuilderTrait;
 use Qdequippe\OAuth2\Client\Provider\SymfonyConnect;
 use PHPUnit\Framework\TestCase;
 use Mockery as m;
+use Qdequippe\OAuth2\Client\Provider\SymfonyConnectResourceOwner;
 
 class SymfonyConnectTest extends TestCase
 {
@@ -90,6 +91,7 @@ class SymfonyConnectTest extends TestCase
 
         $user = $this->provider->getResourceOwner($token);
 
+        $this->assertInstanceOf(SymfonyConnectResourceOwner::class, $user);
         $this->assertEquals('39c049bb-9261-4d85-922c-15730d6fa8b1', $user->getId());
         $this->assertEquals('john@example.com', $user->getEmail());
 
@@ -102,6 +104,7 @@ class SymfonyConnectTest extends TestCase
             ],
             $user->toArray()
         );
+        $this->assertInstanceOf(\DOMElement::class, $user->getData());
     }
 
     public function testExceptionThrownWhenErrorObjectReceived()


### PR DESCRIPTION
This will give access to the complete `<foaf:Person>` Dom Element. SymfonyConnect OAuth response has a lot of data that is not accessible without it. So the easiest and fastest way to get it is to provide an accessor for this Dom Element.

PS as a perfect solution I would like to see an integration of `symfonycorp/connect` library, but it needs more time for implementation, we can discuss it separately 😃 