### PR TITLE
Expose additional fields

### DIFF
--- a/src/Provider/SymfonyConnectResourceOwner.php
+++ b/src/Provider/SymfonyConnectResourceOwner.php
@@ -40,20 +40,22 @@ class SymfonyConnectResourceOwner implements ResourceOwnerInterface
         return $this->data->attributes->getNamedItem('id')->value;
     }
 
-    public function getName()
+    public function getUsername()
     {
-        $username = null;
         $accounts = $this->xpath->query('./foaf:account/foaf:OnlineAccount', $this->data);
         for ($i = 0; $i < $accounts->length; ++$i) {
             $account = $accounts->item($i);
             if ('SymfonyConnect' === $this->getNodeValue('./foaf:name', $account)) {
-                $username = $this->getNodeValue('foaf:accountName', $account);
-
-                break;
+                return $this->getNodeValue('foaf:accountName', $account);
             }
         }
 
-        return $username ?: $this->getNodeValue('./foaf:name', $this->data);
+        return null;
+    }
+
+    public function getName()
+    {
+        return $this->getUsername() ?: $this->getNodeValue('./foaf:name', $this->data);
     }
 
     public function getEmail()
@@ -75,9 +77,20 @@ class SymfonyConnectResourceOwner implements ResourceOwnerInterface
     {
         return [
             'id' => $this->getId(),
+            'username' => $this->getUsername(),
             'name' => $this->getName(),
             'email' => $this->getEmail(),
             'profilePicture' => $this->getProfilePicture(),
+            'realname' => $this->getNodeValue('./foaf:name', $this->data),
+            'biography' => $this->getNodeValue('./bio:olb', $this->data),
+            'birthday' => $this->getNodeValue('./foaf:birthday', $this->data),
+            'city' => $this->getNodeValue('./vcard:locality', $this->data),
+            'country' => $this->getNodeValue('./vcard:country-name', $this->data),
+            'company' => $this->getNodeValue('./cv:hasWorkHistory/cv:employedIn', $this->data),
+            'jobPosition' => $this->getNodeValue('./cv:hasWorkHistory/cv:jobTitle', $this->data),
+            'blogUrl' => $this->getNodeValue('./foaf:weblog', $this->data),
+            'url' => $this->getNodeValue('./foaf:homepage', $this->data),
+            'feedUrl' => $this->getNodeValue('./atom:link[@title="blog/feed"]', $this->data),
         ];
     }
 

--- a/tests/current_user_response.xml
+++ b/tests/current_user_response.xml
@@ -21,6 +21,17 @@
             <foaf:weblog>https://example.com</foaf:weblog>
             <foaf:homepage>https://example.com</foaf:homepage>
             <foaf:mbox>john@example.com</foaf:mbox>
+            <foaf:account>
+                <foaf:OnlineAccount>
+                    <foaf:name>SymfonyConnect</foaf:name>
+                    <foaf:accountName><![CDATA[jdoe]]></foaf:accountName>
+                    <since>Wed, 29 Oct 2008 12:04:33 +0100</since>
+                </foaf:OnlineAccount>
+                <foaf:OnlineAccount>
+                    <foaf:name>github</foaf:name>
+                    <foaf:accountName><![CDATA[jdoe-github]]></foaf:accountName>
+                </foaf:OnlineAccount>
+            </foaf:account>
         </foaf:Person>
     </root>
 </api>

--- a/tests/src/Provider/SymfonyConnectTest.php
+++ b/tests/src/Provider/SymfonyConnectTest.php
@@ -94,13 +94,26 @@ class SymfonyConnectTest extends TestCase
         $this->assertInstanceOf(SymfonyConnectResourceOwner::class, $user);
         $this->assertEquals('39c049bb-9261-4d85-922c-15730d6fa8b1', $user->getId());
         $this->assertEquals('john@example.com', $user->getEmail());
+        $this->assertEquals('jdoe', $user->getUsername());
+        $this->assertEquals('jdoe', $user->getName());
 
         $this->assertEquals(
             [
                 'id' => '39c049bb-9261-4d85-922c-15730d6fa8b1',
-                'name' => 'John Doe',
+                'name' => 'jdoe',
                 'email' => 'john@example.com',
-                'profilePicture' => null
+                'profilePicture' => null,
+                'username' => 'jdoe',
+                'realname' => 'John Doe',
+                'biography' => 'My bio',
+                'birthday' => null,
+                'city' => null,
+                'country' => null,
+                'company' => null,
+                'jobPosition' => null,
+                'blogUrl' => 'https://example.com',
+                'url' => 'https://example.com',
+                'feedUrl' => null,
             ],
             $user->toArray()
         );


### PR DESCRIPTION
This PR update the ResourceOwner to expose more fields.

list of fields extracted from https://github.com/symfonycorp/connect/blob/a6f1a4f29e8e16ad125daf5455297653f7265584/src/Api/Parser/VndComSymfonyConnectXmlParser.php#L158

I'm not sure all fields deserve to have their own getter. Tell me if you don't agree and prefer having `getCity`, `getCountry`, ...