### PR TITLE
Fix deprecation with next version of League\OAuth2

### DIFF
--- a/src/Provider/SymfonyConnect.php
+++ b/src/Provider/SymfonyConnect.php
@@ -4,6 +4,7 @@ namespace Qdequippe\OAuth2\Client\Provider;
 
 use League\OAuth2\Client\Provider\AbstractProvider;
 use League\OAuth2\Client\Provider\Exception\IdentityProviderException;
+use League\OAuth2\Client\Provider\ResourceOwnerInterface;
 use League\OAuth2\Client\Token\AccessToken;
 use Psr\Http\Message\ResponseInterface;
 
@@ -12,31 +13,55 @@ class SymfonyConnect extends AbstractProvider
 
     protected $api = 'https://connect.symfony.com';
 
+    /**
+     * @return string
+     */
+    #[\ReturnTypeWillChange]
     public function getBaseAuthorizationUrl()
     {
         return $this->api . '/oauth/authorize';
     }
 
+    /**
+     * @return string
+     */
+    #[\ReturnTypeWillChange]
     public function getBaseAccessTokenUrl(array $params)
     {
         return $this->api . '/oauth/access_token';
     }
 
+    /**
+     * @return string
+     */
+    #[\ReturnTypeWillChange]
     public function getResourceOwnerDetailsUrl(AccessToken $token)
     {
         return $this->api . '/api?access_token='.$token->getToken();
     }
 
+    /**
+     * @return string
+     */
+    #[\ReturnTypeWillChange]
     protected function getScopeSeparator()
     {
         return ' ';
     }
 
+    /**
+     * @return array
+     */
+    #[\ReturnTypeWillChange]
     protected function getDefaultScopes()
     {
         return ['SCOPE_PUBLIC'];
     }
 
+    /**
+     * @return array
+     */
+    #[\ReturnTypeWillChange]
     protected function parseResponse(ResponseInterface $response)
     {
         $type = $this->getContentType($response);
@@ -48,6 +73,10 @@ class SymfonyConnect extends AbstractProvider
         return ['xml' => (string)$response->getBody()];
     }
 
+    /**
+     * @return void
+     */
+    #[\ReturnTypeWillChange]
     protected function checkResponse(ResponseInterface $response, $data)
     {
         if ($response->getStatusCode() >= 400) {
@@ -59,6 +88,10 @@ class SymfonyConnect extends AbstractProvider
         }
     }
 
+    /**
+     * @return ResourceOwnerInterface
+     */
+    #[\ReturnTypeWillChange]
     protected function createResourceOwner(array $response, AccessToken $token)
     {
         return new SymfonyConnectResourceOwner($response);


### PR DESCRIPTION
This PR fixes deprecations triggered by the `SymfonyConnect`:

> Method "League\OAuth2\Client\Provider\AbstractProvider::getBaseAuthorizationUrl()" might add "string" as a native return type declaration in the future. Do the same in child class "Qdequippe\OAuth2\Client\Provider\SymfonyConnect" now to avoid errors or add an explicit @return annotation to suppress this message.

The composer's file of this project does not contain a minimal version for PHP, I assume, that all versions are supported. 
But their is the `league/oauth2-client: ^2.0` constraint that implicitly requires the minimal version of league/oauth2-client 2.0 which is `PHP >=5.6.0`.

The scalar return type was introduced in PHP 7.0, That's why, I couldn't add a proper return type in this PR, and I had to use a doc bloc + annotation