### PR TITLE
Fix deprecations

### DIFF
--- a/src/Provider/SymfonyConnectResourceOwner.php
+++ b/src/Provider/SymfonyConnectResourceOwner.php
@@ -35,6 +35,9 @@ class SymfonyConnectResourceOwner implements ResourceOwnerInterface
         $this->data = $user->item(0);
     }
 
+    /**
+     * @return mixed
+     **/
     public function getId()
     {
         return $this->data->attributes->getNamedItem('id')->value;


### PR DESCRIPTION
fixes

> Method "League\OAuth2\Client\Provider\ResourceOwnerInterface::getId()" might add "mixed" as a native return type declaration in the future. Do the same in implementation "Qdequippe\OAuth2\Client\Provider\SymfonyConnectResourceOwner" now to avoid errors or add an explicit @return annotation to suppress this message.